### PR TITLE
fix: cap visited post cookie size

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+## [0.4.2] - 2026-05-19
+### Veranderd
+- Beperkt `zw_staart_visited_posts` tot maximaal 100 recente artikel-IDs, zodat de cookie-header niet onbeperkt groeit.
+- Normaliseert de opgeslagen artikel-IDs bij het lezen en schrijven van de cookie.
+
 ## [0.4.1] - 2025-10-20
 ### Veranderd
 - Podcast-links openen nu in nieuwe tabs met `target="_blank"` en `rel="noopener noreferrer"`

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Configureer de verbinding met Plausible Analytics:
 - Data wordt lokaal gecached voor snelle weergave
 
 ### Personalisatie
-- De plugin onthoudt welke artikelen een bezoeker heeft gelezen via een cookie (`zw_staart_visited_posts`, 7 dagen geldig)
+- De plugin onthoudt welke artikelen een bezoeker heeft gelezen via een cookie (`zw_staart_visited_posts`, 7 dagen geldig, maximaal 100 artikelen)
 - Alleen ongelezen artikelen worden getoond in de leestips
 - Het huidige artikel en dossier-artikelen worden automatisch uitgesloten
 - Als er minder dan 5 ongelezen artikelen beschikbaar zijn, wordt het leestips-blok verborgen

--- a/src/front-end.php
+++ b/src/front-end.php
@@ -166,13 +166,13 @@ function zw_staart_top_posts_list() {
 			var topPostItems = document.querySelectorAll('#zw-staart-top-posts-list .zw-staart-top-post-item');
 			var displayedTopPostUrls = [];
 
-			// Function to parse the 'zw_staart_visited_posts' cookie.
 			function getVisitedPostIds() {
-				var cookieValue = document.cookie.split('; ').find(row => row.startsWith('zw_staart_visited_posts='));
-				return cookieValue ? cookieValue.split('=')[1].split(',').map(function(id) {
+				var cookieName = 'zw_staart_visited_posts=';
+				var cookieValue = document.cookie.split('; ').find(row => row.startsWith(cookieName));
+				return cookieValue ? cookieValue.substring(cookieName.length).split(',').map(function(id) {
 					return parseInt(id, 10);
 				}).filter(function(id) {
-					return id > 0 && !isNaN(id);
+					return id > 0;
 				}) : [];
 			}
 

--- a/src/front-end.php
+++ b/src/front-end.php
@@ -169,7 +169,11 @@ function zw_staart_top_posts_list() {
 			// Function to parse the 'zw_staart_visited_posts' cookie.
 			function getVisitedPostIds() {
 				var cookieValue = document.cookie.split('; ').find(row => row.startsWith('zw_staart_visited_posts='));
-				return cookieValue ? cookieValue.split('=')[1].split(',').map(Number) : [];
+				return cookieValue ? cookieValue.split('=')[1].split(',').map(function(id) {
+					return parseInt(id, 10);
+				}).filter(function(id) {
+					return id > 0 && !isNaN(id);
+				}) : [];
 			}
 
 			// Display only the top posts not visited, up to the minimum required.

--- a/src/tracker.php
+++ b/src/tracker.php
@@ -23,15 +23,26 @@ function zw_staart_add_postid_tracker_script(): void {
 			document.addEventListener('DOMContentLoaded', function() {
 				var postId = <?php echo intval( $post->ID ); ?>;
 				var cookieExpiryDays = <?php echo intval( ZW_STAART_COOKIE_EXPIRY_DAYS ); ?>;
+				var maxVisitedPosts = <?php echo intval( ZW_STAART_MAX_VISITED_POSTS ); ?>;
 				updatePostIdCookie(postId);
 
 				function updatePostIdCookie(postId) {
 					var postIds = getCookie('zw_staart_visited_posts');
-					postIds = postIds ? postIds.split(',') : [];
-					if (postIds.indexOf(postId) === -1) {
-						postIds.push(postId);
-					}
+					postIds = postIds ? parsePostIds(postIds) : [];
+					postIds = postIds.filter(function(id) {
+						return id !== postId;
+					});
+					postIds.push(postId);
+					postIds = postIds.slice(-maxVisitedPosts);
 					setCookie('zw_staart_visited_posts', postIds.join(','), cookieExpiryDays);
+				}
+
+				function parsePostIds(value) {
+					return value.split(',').map(function(id) {
+						return parseInt(id, 10);
+					}).filter(function(id, index, postIds) {
+						return id > 0 && !isNaN(id) && postIds.indexOf(id) === index;
+					});
 				}
 
 				function setCookie(name, value, days) {

--- a/src/tracker.php
+++ b/src/tracker.php
@@ -29,6 +29,7 @@ function zw_staart_add_postid_tracker_script(): void {
 				function updatePostIdCookie(postId) {
 					var postIds = getCookie('zw_staart_visited_posts');
 					postIds = postIds ? parsePostIds(postIds) : [];
+					// Move re-visited IDs to the tail so slice(-maxVisitedPosts) keeps the most recent visits.
 					postIds = postIds.filter(function(id) {
 						return id !== postId;
 					});
@@ -41,7 +42,7 @@ function zw_staart_add_postid_tracker_script(): void {
 					return value.split(',').map(function(id) {
 						return parseInt(id, 10);
 					}).filter(function(id, index, postIds) {
-						return id > 0 && !isNaN(id) && postIds.indexOf(id) === index;
+						return id > 0 && postIds.lastIndexOf(id) === index;
 					});
 				}
 

--- a/zw-staart.php
+++ b/zw-staart.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: ZuidWest Staart
  * Description: Toont leestips of podcast-promo onder artikelen voor betere recirculatie en engagement
- * Version: 0.4.1
+ * Version: 0.4.2
  * Author: Streekomroep ZuidWest
  * Author URI: https://www.zuidwesttv.nl
  * Plugin URI: https://github.com/oszuidwest/zw-staart
@@ -19,7 +19,7 @@ defined( 'ABSPATH' ) || die( 'No script kiddies please!' );
 
 // Plugin version and metadata.
 if ( ! defined( 'ZW_STAART_VERSION' ) ) {
-	define( 'ZW_STAART_VERSION', '0.4.1' );
+	define( 'ZW_STAART_VERSION', '0.4.2' );
 }
 if ( ! defined( 'ZW_STAART_PLUGIN_FILE' ) ) {
 	define( 'ZW_STAART_PLUGIN_FILE', __FILE__ );
@@ -40,6 +40,9 @@ if ( ! defined( 'ZW_STAART_COOKIE_EXPIRY_DAYS' ) ) {
 }
 if ( ! defined( 'ZW_STAART_MAX_TOP_ARTICLES' ) ) {
 	define( 'ZW_STAART_MAX_TOP_ARTICLES', 25 );      // Maximum articles to cache.
+}
+if ( ! defined( 'ZW_STAART_MAX_VISITED_POSTS' ) ) {
+	define( 'ZW_STAART_MAX_VISITED_POSTS', 100 );    // Maximum visited post IDs to keep in the cookie.
 }
 if ( ! defined( 'ZW_STAART_MIN_POSTS_DISPLAY' ) ) {
 	define( 'ZW_STAART_MIN_POSTS_DISPLAY', 5 );      // Minimum posts to show list.


### PR DESCRIPTION
## Summary
- cap `zw_staart_visited_posts` to the most recent 100 post IDs
- move revisited articles to the end so the cookie keeps recent history
- normalize stored IDs when reading and writing the cookie
- bump plugin version to 0.4.2 and update docs/changelog

## Verification
- `php -l zw-staart.php`
- `php -l src/tracker.php`
- `php -l src/front-end.php`
- `git diff --check`

Relates oszuidwest/operations-issues#41