### PR TITLE
chore: require WordPress 7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Alleen artikel-links bevatten UTM-parameters voor campagne-tracking. Podcast-lin
 
 ## Vereisten
 
-- WordPress 6.0 of hoger
-- PHP 8.1 of hoger
+- WordPress 7.0 of hoger
+- PHP 8.3 of hoger
 - JavaScript voor 50/50 selectie en cookie tracking
 - Plausible Analytics account (voor leestips functionaliteit)

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,7 +15,7 @@
 
     <!-- Versions -->
     <config name="testVersion" value="8.3-8.4"/>
-    <config name="minimum_wp_version" value="6.8"/>
+    <config name="minimum_wp_version" value="7.0"/>
 
     <!-- Per-plugin -->
     <config name="text_domain" value="zw-staart"/>

--- a/zw-staart.php
+++ b/zw-staart.php
@@ -6,9 +6,9 @@
  * Author: Streekomroep ZuidWest
  * Author URI: https://www.zuidwesttv.nl
  * Plugin URI: https://github.com/oszuidwest/zw-staart
- * Requires at least: 6.0
- * Tested up to: 6.8
- * Requires PHP: 8.1
+ * Requires at least: 7.0
+ * Tested up to: 7.0
+ * Requires PHP: 8.3
  * License: GPL-2.0-or-later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  *


### PR DESCRIPTION
## Summary

- Raise the plugin header and documented minimum WordPress version from 6.0 to 7.0.
- Mark the plugin as tested through WordPress 7.0.
- Align the declared PHP requirement with the existing Composer requirement of PHP 8.3.

## Compatibility audit

- Reviewed the WordPress 6.7, 6.8, 6.9, and 7.0 developer field guides, including the current WordPress 7.0.2 maintenance release.
- Checked the plugin's WordPress API calls against Core functions removed or deprecated through 7.0.
- Ran Plugin Check 2.0.0 in update mode and reviewed the findings for runtime relevance.
- Activated the plugin alongside the complete oszuidwest plugin set on WordPress 7.0.2 and PHP 8.3.32.

The audit found no additional WordPress 7 code changes required.

## Verification

- PHPStan
- PHP syntax check
- Plugin Check 2.0.0 review
- Full-set activation on WordPress 7.0.2 / PHP 8.3.32

## References

- [WordPress 6.7 field guide](https://make.wordpress.org/core/2024/10/23/wordpress-6-7-field-guide/)
- [WordPress 6.8 field guide](https://make.wordpress.org/core/2025/03/28/wordpress-6-8-field-guide/)
- [WordPress 6.9 field guide](https://make.wordpress.org/core/2025/11/25/wordpress-6-9-field-guide/)
- [WordPress 7.0 field guide](https://make.wordpress.org/core/2026/05/14/wordpress-7-0-field-guide/)
- [WordPress 7.0.2 release](https://wordpress.org/news/2026/07/wordpress-7-0-2-release/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the minimum requirements to WordPress 7.0+ and PHP 8.3+.

* **Chores**
  * Updated plugin compatibility metadata to reflect WordPress 7.0 and PHP 8.3.
  * Raised the configured WordPress compatibility baseline in the coding standards configuration to 7.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->